### PR TITLE
feat(release): enable automatic Sonatype Central publishing (autoPulbish=true, waitUntil=published)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
     outputs:
       artifact-hashes: ${{ steps.hash.outputs.hashes }}
       sbom-hash: ${{ steps.sbom-hash.outputs.hash }}
+      version: ${{ steps.version.outputs.version }}
+      build_timestamp: ${{ steps.ts.outputs.build_timestamp }}
       total_tests: ${{ steps.test-results.outputs.total_tests }}
       passed_tests: ${{ steps.test-results.outputs.passed_tests }}
       failed_tests: ${{ steps.test-results.outputs.failed_tests }}
@@ -47,6 +49,11 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        
+    - name: Install tooling (xmllint, bc)
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libxml2-utils bc
         
     - name: Determine version
       id: version
@@ -77,6 +84,11 @@ jobs:
         fi
         
         echo "✅ Version format is valid: $VERSION"
+        
+    - name: Compute build timestamp
+      id: ts
+      run: |
+        echo "build_timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
         
     - name: Update Maven version
       run: |
@@ -228,7 +240,7 @@ jobs:
       id: test-results
       run: |
         # Parse test results
-        if [ -f "target/surefire-reports/TEST-"*.xml ]; then
+        if ls target/surefire-reports/TEST-*.xml 1> /dev/null 2>&1; then
           TOTAL_TESTS=$(xmllint --xpath "sum(//testsuite/@tests)" target/surefire-reports/TEST-*.xml 2>/dev/null || echo "0")
           FAILURES=$(xmllint --xpath "sum(//testsuite/@failures)" target/surefire-reports/TEST-*.xml 2>/dev/null || echo "0")
           ERRORS=$(xmllint --xpath "sum(//testsuite/@errors)" target/surefire-reports/TEST-*.xml 2>/dev/null || echo "0")
@@ -573,66 +585,6 @@ jobs:
         [ -f "target/ghrelasset-wagon-${VERSION}-javadoc.jar" ] || { echo "❌ Javadoc JAR not found"; exit 1; }
         echo "✅ All required artifacts present"
         
-    # - name: Deploy to Maven Central using pre-built artifacts
-    #   env:
-    #     MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-    #     MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
-    #   run: |
-    #     echo "🚀 Deploying pre-built artifacts to Maven Central..."
-        
-    #     # Function to deploy with retry logic
-    #     deploy_with_retry() {
-    #       local file="$1"
-    #       local classifier="$2"
-    #       local max_retries=3
-    #       local retry_count=0
-          
-    #       while [ $retry_count -lt $max_retries ]; do
-    #         echo "Deploying $file (attempt $((retry_count + 1))/$max_retries)..."
-            
-    #         if [ -z "$classifier" ]; then
-    #           # Deploy main JAR with POM
-    #           if mvn deploy:deploy-file \
-    #             -Dfile="$file" \
-    #             -DpomFile=target/ghrelasset-wagon-0.0.1.pom \
-    #             -Durl=https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/ \
-    #             -DrepositoryId=central \
-    #             -s ${{ github.workspace }}/settings.xml; then
-    #             echo "✅ Successfully deployed $file"
-    #             return 0
-    #           fi
-    #         else
-    #           # Deploy classified JAR
-    #           if mvn deploy:deploy-file \
-    #             -Dfile="$file" \
-    #             -DgroupId=io.github.amadeusitgroup.maven.wagon \
-    #             -DartifactId=ghrelasset-wagon \
-    #             -Dversion=0.0.1 \
-    #             -Dpackaging=jar \
-    #             -Dclassifier="$classifier" \
-    #             -Durl=https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/ \
-    #             -DrepositoryId=central \
-    #             -s ${{ github.workspace }}/settings.xml; then
-    #             echo "✅ Successfully deployed $file"
-    #             return 0
-    #           fi
-    #         fi
-            
-    #         retry_count=$((retry_count + 1))
-    #         if [ $retry_count -lt $max_retries ]; then
-    #           echo "⚠️ Deployment failed, retrying in 10 seconds..."
-    #           sleep 10
-    #         fi
-    #       done
-          
-    #       echo "❌ Failed to deploy $file after $max_retries attempts"
-    #       return 1
-    #     }
-        
-    #     # Deploy artifacts with retry logic
-    #     deploy_with_retry "target/ghrelasset-wagon-0.0.1.jar" "" || exit 1
-    #     deploy_with_retry "target/ghrelasset-wagon-0.0.1-sources.jar" "sources" || exit 1
-    #     deploy_with_retry "target/ghrelasset-wagon-0.0.1-javadoc.jar" "javadoc" || exit 1
         
     #     echo "✅ All artifacts deployed successfully"
     - name: Import GPG key
@@ -779,61 +731,57 @@ jobs:
           attestations/build-metadata.json
           slsa/*.intoto.jsonl
         body: |
-          ## 🚀 Release Build Summary
-          
-          **Build Information:**
-          - **Build Timestamp:** $(date -u +%Y-%m-%dT%H:%M:%SZ)
+          ## 🚀 Release Summary
+
+          ### 🏗️ Build Information
+          - **Build Timestamp:** ${{ needs.build-and-attest.outputs.build_timestamp }}
           - **Git Commit:** ${{ github.sha }}
           - **Workflow Run:** [${{ github.run_number }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
           - **Java Version:** 17
-          - **Maven Version:** $(mvn --version | head -1 | cut -d' ' -f3)
-          
-          ## 🧪 Test Results
-          
-          | Metric | Value |
-          |--------|-------|
-          | Total Tests | ${{ needs.build-and-attest.outputs.total_tests || 'N/A' }} |
-          | Passed | ${{ needs.build-and-attest.outputs.passed_tests || 'N/A' }} |
-          | Failed | ${{ needs.build-and-attest.outputs.failed_tests || 'N/A' }} |
-          | Success Rate | ${{ needs.build-and-attest.outputs.success_rate || 'N/A' }} |
-          
-          ## 📈 Code Coverage
-          
-          | Coverage Type | Percentage |
-          |---------------|------------|
-          | Instructions | ${{ needs.build-and-attest.outputs.instruction_coverage || 'N/A' }} |
-          | Branches | ${{ needs.build-and-attest.outputs.branch_coverage || 'N/A' }} |
-          | Lines | ${{ needs.build-and-attest.outputs.line_coverage || 'N/A' }} |
-          
-          ## 🔒 Security Attestations
-          
+
+          ### 🧪 Test Results
+          - **Total Tests:** ${{ needs.build-and-attest.outputs.total_tests }}
+          - **Passed:** ${{ needs.build-and-attest.outputs.passed_tests }}
+          - **Failed:** ${{ needs.build-and-attest.outputs.failed_tests }}
+          - **Success Rate:** ${{ needs.build-and-attest.outputs.success_rate }}
+
+          ### 📈 Code Coverage
+          - **Instructions:** ${{ needs.build-and-attest.outputs.instruction_coverage }}
+          - **Branches:** ${{ needs.build-and-attest.outputs.branch_coverage }}
+          - **Lines:** ${{ needs.build-and-attest.outputs.line_coverage }}
+
+          ### 📦 Maven Central
+          - **Coordinates:** `io.github.amadeusitgroup.maven.wagon:ghrelasset-wagon:${{ needs.build-and-attest.outputs.version }}`
+          - **Artifact:** https://central.sonatype.com/artifact/io.github.amadeusitgroup.maven.wagon/ghrelasset-wagon/${{ needs.build-and-attest.outputs.version }}
+
+          ### 🔒 Security Attestations
           This release includes comprehensive security attestations and provenance information:
-          
-          ### 📋 Software Bill of Materials (SBOM)
-          - **SPDX Format**: sbom.spdx.json
-          - **CycloneDX Format**: sbom.cyclonedx.json
-          
-          ### 🛡️ Security Scanning
-          - **Vulnerability Report**: vulnerability-report.json
-          - **SARIF Report**: trivy-results.sarif
-          
-          ### 🔐 Provenance & Attestations
-          - **SLSA Provenance**: *.intoto.jsonl (SLSA Level 3)
-          - **Build Metadata**: build-metadata.json
-          - **Artifact Hashes**: *.sha256
-          
-          ### ✍️ Code Signing
+
+          #### 📋 Software Bill of Materials (SBOM)
+          - **SPDX Format:** sbom.spdx.json
+          - **CycloneDX Format:** sbom.cyclonedx.json
+
+          #### 🛡️ Security Scanning
+          - **Vulnerability Report:** vulnerability-report.json
+          - **SARIF Report:** trivy-results.sarif
+
+          #### 🔐 Provenance & Attestations
+          - **SLSA Provenance:** *.intoto.jsonl (provenance attestations)
+          - **Build Metadata:** build-metadata.json
+          - **Artifact Hashes:** *.sha256
+
+          #### ✍️ Code Signing
           - All artifacts are signed with GPG
           - Signature files: *.asc
-          
-          ## 📦 Release Artifacts
-          
+
+          ### 📦 Release Artifacts
+
           **Main Artifacts:**
-          - JAR: ghrelasset-wagon-*.jar
-          - Sources: ghrelasset-wagon-*-sources.jar
-          - Javadoc: ghrelasset-wagon-*-javadoc.jar
-          - POM: ghrelasset-wagon-*.pom
-          
+          - JAR: ghrelasset-wagon-${{ needs.build-and-attest.outputs.version }}.jar
+          - Sources: ghrelasset-wagon-${{ needs.build-and-attest.outputs.version }}-sources.jar
+          - Javadoc: ghrelasset-wagon-${{ needs.build-and-attest.outputs.version }}-javadoc.jar
+          - POM: ghrelasset-wagon-${{ needs.build-and-attest.outputs.version }}.pom
+
           **Attestation Artifacts:**
           - sbom.spdx.json - SPDX Software Bill of Materials
           - sbom.cyclonedx.json - CycloneDX Software Bill of Materials
@@ -841,18 +789,16 @@ jobs:
           - build-metadata.json - Build environment metadata
           - *.sha256 - SHA-256 checksums
           - *.asc - GPG signatures
-          
-          ## 🔍 Verification
-          
+
+          ### 🔍 Verification
           See the attached VERIFICATION.md file for detailed instructions on verifying GPG signatures, SHA256 hashes, SLSA provenance, and scanning SBOMs for vulnerabilities.
-          
-          ## 🏗️ Build Environment
-          
+
+          ### 🏗️ Build Environment
           - **Runner OS:** ubuntu-latest
           - **Build Actor:** ${{ github.actor }}
           - **Repository:** ${{ github.repository }}
           - **Event:** ${{ github.event_name }}
-          
+
           All attestations are also available in Maven Central alongside the published artifacts.
-          
+
           For detailed information about security attestations, see [Security Attestations Documentation](docs/SECURITY_ATTESTATIONS.md).

--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@ The GhRelAssetWagon project is designed to integrate GitHub Release Assets as a 
 
 # High level design
 
-```
-+------------------+      +---------------------+      +-----------------------+
-| Maven Project    | ---> | GhRelAssetWagon     | ---> | GitHub Release Assets |
-| (pom.xml)        |      | (Maven Wagon API)   |      | (as Maven Repository) |
-+------------------+      +---------------------+      +-----------------------+
+```mermaid
+flowchart LR
+    A["Maven Project 
+    (pom.xml)" ] --> B["GhRelAssetWagon
+    (Maven Wagon API)"]
+    B --> C["GitHub Release Assets
+    (as Maven Repository)"]
 ```
 
 The diagram above illustrates the integration of [`GhRelAssetWagon`]("src/main/java/io/github/amadeusitgroup/maven/wagon/GhRelAssetWagon.java") within the Maven ecosystem. It acts as a bridge between a Maven project and GitHub Release Assets, treating the latter as a Maven repository. This setup enables Maven to resolve and download dependencies stored as assets in GitHub releases.
@@ -122,19 +124,19 @@ GhRelAssetWagon
 - **Metadata Generation**: Creates proper Maven metadata files
 - **Path Validation**: Ensures proper Maven repository structure
 
-### Phase 2: Maven Repository Standards Compliance
+### Repository Standards Compliance
 - **Maven Metadata Handler**: Generates XML metadata for group, artifact, and version levels
 - **Repository Validator**: Validates Maven repository paths and extracts coordinates
 - **Enhanced Checksum Support**: Multiple checksum algorithms with validation
 
-### Phase 3: Performance & Reliability Enhancements
+### Performance & Reliability Enhancements
 - **Connection Pooling**: Thread-safe connection pooling for GitHub API calls
 - **Rate Limit Handling**: Intelligent GitHub API rate limit detection and throttling
 - **Retry Logic**: Configurable retry with exponential backoff and jitter
 - **Circuit Breaker**: Three-state circuit breaker for fail-fast behavior
 - **Async Operations**: Thread pool-based asynchronous task execution
 
-### Phase 4: Advanced Features
+### Advanced Features
 - **Parallel Operations**: Concurrent file uploads and downloads with thread pool management
 - **Delta Sync**: Incremental synchronization with snapshot-based change detection
 - **Compression Support**: Multi-format compression (GZIP, ZIP, TAR) with configurable levels
@@ -158,8 +160,8 @@ GhRelAssetWagon
 - **Complex Artifact Support**: Support for artifacts with classifiers and complex extensions (e.g., `.tar.gz`)
 
 ### Quality Assurance
-- **Comprehensive Testing**: 183 unit tests covering all Phase 4 components with 100% pass rate
-- **Test-Driven Development**: All Phase 4 features implemented using TDD methodology
+- **Comprehensive Testing**: Extensive unit tests covering core and advanced components with a 100% pass rate
+- **Test-Driven Development**: Features implemented using TDD methodology
 - **Continuous Integration**: Automated testing, security scanning, and coverage reporting
 - **Maven Central Ready**: Full GPG signing and deployment pipeline for Maven Central distribution
 - **Security Scanning**: Integrated Trivy vulnerability scanning and SBOM generation
@@ -301,7 +303,7 @@ mvn clean install
 
 ## Advanced Configuration
 
-### Phase 4 Configuration Options
+### Configuration Options
 
 The GhRelAssetWagon supports external configuration through the `ConfigurationManager`. Create a configuration file (e.g., `ghrelasset-config.json`) with the following options:
 
@@ -339,10 +341,11 @@ The GhRelAssetWagon supports external configuration through the `ConfigurationMa
 
 ## Testing
 
+### Component Tests 
 The GhRelAssetWagon project includes comprehensive unit tests covering all components:
 
 - **Core Tests**: `GhRelAssetWagonTest.java` - Main wagon functionality
-- **Phase 4 Tests**: 
+- **Component Tests**: 
   - `ParallelOperationManagerTest.java` - Parallel operations
   - `DeltaSyncManagerTest.java` - Delta synchronization
   - `CompressionHandlerTest.java` - Compression features

--- a/README.md
+++ b/README.md
@@ -160,14 +160,14 @@ GhRelAssetWagon
 - **Complex Artifact Support**: Support for artifacts with classifiers and complex extensions (e.g., `.tar.gz`)
 
 ### Quality Assurance
-- **Comprehensive Testing**: Extensive unit tests covering core and advanced components with a 100% pass rate
+- **Comprehensive Testing**: Extensive unit test coverage across core and advanced components
 - **Test-Driven Development**: Features implemented using TDD methodology
 - **Continuous Integration**: Automated testing, security scanning, and coverage reporting
 - **Maven Central Ready**: Full GPG signing and deployment pipeline for Maven Central distribution
 - **Security Scanning**: Integrated Trivy vulnerability scanning and SBOM generation
 
 ### Security Attestations & Provenance
-- **SLSA Level 3 Provenance**: Cryptographically signed build provenance with GitHub attestations
+- **Provenance Attestations**: Cryptographically signed build provenance published via GitHub Attestations and SLSA tooling (effective SLSA level depends on CI configuration)
 - **Software Bill of Materials**: SPDX and CycloneDX format SBOMs published to Maven Central
 - **Vulnerability Scanning**: Comprehensive security reports in SARIF and JSON formats
 - **Code Signing**: GPG-signed artifacts with SHA-256 checksums for integrity verification

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,7 +21,7 @@ The wagon implements the essential StreamWagon methods for efficient streaming o
 - `put(File, String)` - Stages artifacts for upload to GitHub releases
 - `openConnectionInternal()` - Establishes authentication and downloads repository cache
 
-### Enhanced Wagon Interface Methods (Phase 1)
+### Enhanced Wagon Interface Methods
 - `getFileList(String)` - Lists all files in a GitHub release directory
 - `resourceExists(String)` - Checks if a specific resource exists in the release
 - `putDirectory(File, String)` - Uploads entire directories as individual release assets
@@ -31,7 +31,7 @@ The wagon implements the essential StreamWagon methods for efficient streaming o
 ## Project Information
 
 - **Organization**: Amadeus IT Group
-- **License**: Apache License 2.0
+- **License**: MIT License
 - **Java Version**: 1.8+
 - **Maven Version**: 3.x
 - **Current Version**: 0.0.1
@@ -79,19 +79,19 @@ graph TB
 - **Temporary File Management**: Efficient handling of upload staging with automatic cleanup
 - **Maven Compliance**: Full compatibility with Maven's preferred streaming architecture
 
-### 2. Phase 2: Maven Repository Standards Compliance
+### 2. Repository Standards Compliance
 - **MavenMetadataHandler**: Generates Maven metadata XML files for group, artifact, and version levels
 - **ChecksumHandler**: Handles MD5, SHA-1, and SHA-256 checksum generation and validation
 - **RepositoryValidator**: Validates Maven repository paths and extracts coordinates
 
-### 3. Phase 3: Performance & Reliability Enhancements
+### 3. Performance & Reliability Enhancements
 - **ConnectionPoolManager**: Thread-safe connection pooling for GitHub API calls
 - **RateLimitHandler**: GitHub API rate limit detection and intelligent throttling
 - **RetryHandler**: Configurable retry logic with exponential backoff and jitter
 - **CircuitBreakerHandler**: Three-state circuit breaker for fail-fast behavior
 - **AsyncOperationManager**: Thread pool-based async task execution
 
-### 4. Phase 4: Advanced Features
+### 4. Advanced Features
 - **ParallelOperationManager**: Concurrent file operations with thread pool management
 - **DeltaSyncManager**: Incremental synchronization with snapshot-based change detection
 - **CompressionHandler**: File compression/decompression with multiple algorithms
@@ -290,7 +290,7 @@ export GH_RELEASE_ASSET_TOKEN="/path/to/token/file"
     <extension>
       <groupId>io.github.amadeusitgroup.maven.wagon</groupId>
       <artifactId>ghrelasset-wagon</artifactId>
-      <version>1.0.0</version>
+      <version>0.0.1</version>
     </extension>
   </extensions>
 </build>
@@ -310,7 +310,7 @@ export GH_RELEASE_ASSET_TOKEN="/path/to/token/file"
     <extension>
       <groupId>io.github.amadeusitgroup.maven.wagon</groupId>
       <artifactId>ghrelasset-wagon</artifactId>
-      <version>1.0.0</version>
+      <version>0.0.1</version>
     </extension>
   </extensions>
 </build>
@@ -367,7 +367,7 @@ export GH_RELEASE_ASSET_TOKEN="/path/to/token/file"
 
 ### Test Structure
 ```
-src/test/java/com/amadeus/maven/wagon/GhRelAssetWagonTest.java
+src/test/java/io/github/amadeusitgroup/maven/wagon/GhRelAssetWagonTest.java
 ```
 
 ### CI/CD
@@ -405,7 +405,7 @@ The wagon includes extensive logging for troubleshooting:
 
 ## Future Enhancements
 
-### Phase 4 Features (Implemented)
+### Advanced Features (Implemented)
 - ✅ **Parallel Operations**: Concurrent uploads and downloads with thread pool management
 - ✅ **Delta Sync**: Incremental synchronization with snapshot-based change detection
 - ✅ **Compression Support**: Multi-format compression (GZIP, ZIP, TAR) with configurable levels

--- a/pom.xml
+++ b/pom.xml
@@ -215,8 +215,8 @@
                 <extensions>true</extensions>
                 <configuration>
                     <publishingServerId>central</publishingServerId>
-                    <autoPublish>false</autoPublish>
-                    <waitUntil>validated</waitUntil>
+                    <autoPublish>true</autoPublish>
+                    <waitUntil>published</waitUntil>
                     <includeAttestations>true</includeAttestations>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Removes manual publishing step by configuring central-publishing-maven-plugin to auto-publish and wait for completion. This allows fully non-interactive releases from CI.