### PR TITLE
fix: multiple issues

### DIFF
--- a/src/test/java/io/github/amadeusitgroup/maven/wagon/GhRelAssetWagonTest.java
+++ b/src/test/java/io/github/amadeusitgroup/maven/wagon/GhRelAssetWagonTest.java
@@ -1,5 +1,6 @@
 package io.github.amadeusitgroup.maven.wagon;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.DisplayName;
@@ -38,6 +39,11 @@ public class GhRelAssetWagonTest {
                 ghRelAssetWagon.setUploadEndpoint(wmRuntimeInfo.getHttpBaseUrl());
                 // set up a mock repository for testing
                 ghRelAssetWagon.setRepository("test-repo", "ghrelasset://owner/repo/v1.0.0/test-asset.zip");
+        }
+
+        @AfterEach
+        public void tearDown() throws Exception {
+                ghRelAssetWagon.closeConnection();
         }
 
         @Test


### PR DESCRIPTION
- Appends new files to the Zip in place. This improves the performance and also fixes a resource contention issue faced when overwriting the whole zip for each new file.
- Ensures that the proper `TransferEvents` are reported during the `GET` operation. Without this, Maven tries to validate checksums before the GET is finalized, leading to it generating a SHA for an incomplete file.
- Fixed up the `fillOutputData` method so it actually adds files to the zip rather than trying to upload them as separate assets.
  - __Note__: a future enhancement would be to try and more fully rely on implementation of the abstract methods `fillInputData` and `fillOutputData` rather than overriding `get` and `put` etc. since `StreamWagon` already provides implementations for those which handle transfers with proper event reporting.