### PR TITLE
fix: resourceExists check

### DIFF
--- a/src/main/java/io/github/amadeusitgroup/maven/wagon/GhRelAssetRepository.java
+++ b/src/main/java/io/github/amadeusitgroup/maven/wagon/GhRelAssetRepository.java
@@ -1,0 +1,43 @@
+package io.github.amadeusitgroup.maven.wagon;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.maven.wagon.repository.Repository;
+
+public class GhRelAssetRepository extends Repository {
+
+  private static final Pattern REPO_URL_PATTERN =
+      Pattern.compile("^ghrelasset://(?<org>[^/]+)/(?<repo>[^/]+)/(?<tag>[^/]+)/(?<asset>[^/]+\\.zip)$");
+
+  private final String repoOwner;
+  private final String repoName;
+  private final String tag;
+  private final String assetName;
+
+  public GhRelAssetRepository(Repository repository) {
+    super(repository.getId(), repository.getUrl());
+
+    Matcher m = REPO_URL_PATTERN.matcher(repository.getUrl());
+    if (!m.matches()) {
+      throw new IllegalArgumentException("Invalid repository URL: " + repository.getUrl());
+    }
+
+    this.repoOwner = m.group("org");
+    this.repoName = m.group("repo");
+    this.tag = m.group("tag");
+    this.assetName = m.group("asset");
+  }
+
+  public String getGitHubRepository() {
+    return repoOwner + "/" + repoName;
+  }
+
+  public String getTag() {
+    return tag;
+  }
+
+  public String getAssetName() {
+    return assetName;
+  }
+}

--- a/src/main/java/io/github/amadeusitgroup/maven/wagon/ZipCacheManager.java
+++ b/src/main/java/io/github/amadeusitgroup/maven/wagon/ZipCacheManager.java
@@ -1,0 +1,142 @@
+package io.github.amadeusitgroup.maven.wagon;
+
+import javax.xml.bind.DatatypeConverter;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.io.FileUtils;
+
+public class ZipCacheManager {
+
+  private final Path cacheDirectory;
+
+  private File cacheFile;
+  private FileSystem zipFileSystem;
+
+  public ZipCacheManager() {
+    this(Paths.get(System.getProperty("user.home"), ".ghrelasset/repos"));
+  }
+
+  public ZipCacheManager(Path cacheDirectory) {
+    this.cacheDirectory = cacheDirectory;
+  }
+
+  /**
+   * Checks if the cache file has been created.
+   *
+   * @return {@code true} if the cache file exists, {@code false} otherwise.
+   */
+  public boolean isInitialized() {
+    return cacheFile != null && cacheFile.exists();
+  }
+
+  /**
+   * Initializes the cache manager. It computes the cache file name based on the repository URL and copies the
+   * content of the input stream to it. If the cache is already initialized, this method does nothing.
+   *
+   * @param repository    the {@link GhRelAssetRepository} being used.
+   * @param inputStream   the {@link InputStream} of the zip asset. Can be null if the asset doesn't exist.
+   * @throws IOException if an I/O error occurs when creating the cache file or directories.
+   */
+  public void initialize(GhRelAssetRepository repository, InputStream inputStream) throws IOException {
+    if (isInitialized()) {
+      return;
+    }
+
+    String cacheFileName = getSHA1(repository.getUrl());
+    this.cacheFile = cacheDirectory.resolve(cacheFileName).toFile();
+
+    if (inputStream != null) {
+      if (!cacheFile.getParentFile().exists()) {
+        cacheFile.getParentFile().mkdirs();
+      }
+
+      FileUtils.copyInputStreamToFile(inputStream, this.cacheFile);
+    }
+    // null input indicates zip asset not found, could be first time execution
+  }
+
+  /**
+   * Returns the cache file.
+   *
+   * @return The cache {@link File}.
+   */
+  public File getCacheFile() {
+    return cacheFile;
+  }
+
+  /**
+   * Gets the {@link FileSystem} for the zip cache. It will be created if it doesn't exist.
+   *
+   * @return the zip {@link FileSystem}.
+   * @throws IOException           if an I/O error occurs.
+   * @throws IllegalStateException if the cache has not been initialized.
+   */
+  public FileSystem getZipFileSystem() throws IOException {
+    if (!isInitialized()) {
+      throw new IllegalStateException("ZipCacheManager has not been initialized");
+    }
+
+    if (zipFileSystem == null) {
+      initialiseZipFileSystem(this.getCacheFile());
+    }
+
+    return zipFileSystem;
+  }
+
+  /**
+   * Closes the zip {@link FileSystem} if it has been created.
+   *
+   * @throws IOException if an I/O error occurs closing the file system.
+   */
+  public void close() throws IOException {
+    if (zipFileSystem != null) {
+      zipFileSystem.close();
+    }
+  }
+
+  /**
+   * Calculates the SHA-1 hash value of the given input string.
+   *
+   * @param input the input string to calculate the hash value for
+   * @return the SHA-1 hash value of the input string
+   * @throws IllegalArgumentException if SHA-1 algorithm is not available
+   */
+  private String getSHA1(String input) {
+    try {
+      MessageDigest md = MessageDigest.getInstance("SHA-1");
+      md.update(input.getBytes());
+      byte[] digest = md.digest();
+      System.out.println("GhRelAssetWagon: SHA-1: " + DatatypeConverter.printHexBinary(digest));
+      return DatatypeConverter.printHexBinary(digest);
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalArgumentException("SHA1 algorithm unavailable", e);
+    }
+  }
+
+  /**
+   * In order to write new files to an existing Zip a new {@link java.io.FileSystem} is created.
+   * A reference is maintained to avoid recreating for each new file, then the Filesystem is closed in {@link #close()}
+   *
+   * @param zipRepo the zipRepo to initialize the FileSystem for
+   * @throws IOException if an I/O error occurs whilst initializing the FileSystem
+   */
+  void initialiseZipFileSystem(File zipRepo) throws IOException {
+    if (this.zipFileSystem == null || !this.zipFileSystem.isOpen()) {
+      Map<String, String> env = new HashMap<>();
+      env.put("create", "true");
+      URI uri = URI.create("jar:" + zipRepo.toURI());
+      this.zipFileSystem = FileSystems.newFileSystem(uri, env);
+    }
+  }
+}

--- a/src/test/java/io/github/amadeusitgroup/maven/wagon/GhRelAssetRepositoryTest.java
+++ b/src/test/java/io/github/amadeusitgroup/maven/wagon/GhRelAssetRepositoryTest.java
@@ -1,0 +1,39 @@
+package io.github.amadeusitgroup.maven.wagon;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.apache.maven.wagon.repository.Repository;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class GhRelAssetRepositoryTest {
+
+  @ParameterizedTest
+  @CsvSource({
+      "ghrelasset://my-org/my-repo/v1.0.0/my-asset.zip, my-org/my-repo, v1.0.0, my-asset.zip",
+      "ghrelasset://another-org/another-repo/latest/another-asset.zip, another-org/another-repo, latest, another-asset.zip",
+      "ghrelasset://a/b/c/d.zip, a/b, c, d.zip"
+  })
+  void testValidRepositoryUrl(String url, String expectedRepo, String expectedTag, String expectedAsset) {
+    Repository repository = new Repository("someId", url);
+    GhRelAssetRepository ghRelAssetRepository = new GhRelAssetRepository(repository);
+
+    assertEquals(expectedRepo, ghRelAssetRepository.getGitHubRepository());
+    assertEquals(expectedTag, ghRelAssetRepository.getTag());
+    assertEquals(expectedAsset, ghRelAssetRepository.getAssetName());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "ghrelasset://invalid-url",
+      "ghrelasset://org/repo/tag",
+      "ghrelasset://org/repo/tag/asset-without-zip-extension",
+      "ghrelasset://org/repo/tag/asset-ending-zip",
+      "http://github.com/org/repo",
+      ""
+  })
+  void testInvalidRepositoryUrl(String url) {
+    Repository repository = new Repository("someId", url);
+    assertThrows(IllegalArgumentException.class, () -> new GhRelAssetRepository(repository));
+  }
+}

--- a/src/test/java/io/github/amadeusitgroup/maven/wagon/GhRelAssetWagonTest.java
+++ b/src/test/java/io/github/amadeusitgroup/maven/wagon/GhRelAssetWagonTest.java
@@ -9,20 +9,28 @@ import org.apache.maven.wagon.repository.Repository;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.security.MessageDigest;
-import java.time.Instant;
-import java.util.HexFormat;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+
 import static org.mockito.Mockito.*;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 
 @WireMockTest()
 public class GhRelAssetWagonTest {
+
+        @TempDir
+        Path tempDir;
 
         private GhRelAssetWagon ghRelAssetWagon;
         private AuthenticationInfo authenticationInfo;
@@ -30,7 +38,7 @@ public class GhRelAssetWagonTest {
 
         @BeforeEach
         public void setUp(WireMockRuntimeInfo wmRuntimeInfo) {
-                ghRelAssetWagon = new GhRelAssetWagon();
+                ghRelAssetWagon = spy(GhRelAssetWagon.class);
                 authenticationInfo = mock(AuthenticationInfo.class);
                 repository = new Repository("test-repo", "ghrelasset://owner/repo/v1.0.0/test-asset.zip");
                 ghRelAssetWagon.setAuthenticationInfo(authenticationInfo);
@@ -44,16 +52,6 @@ public class GhRelAssetWagonTest {
         @AfterEach
         public void tearDown() throws Exception {
                 ghRelAssetWagon.closeConnection();
-        }
-
-        @Test
-        public void testGetSHA1() throws Exception {
-                String input = "test_input";
-                MessageDigest md = MessageDigest.getInstance("SHA-1");
-                byte[] digest = md.digest(input.getBytes());
-                String expectedSha1 = HexFormat.of().formatHex(digest).toUpperCase();
-                String sha1 = ghRelAssetWagon.getSHA1(input);
-                assertEquals(expectedSha1, sha1);
         }
 
         @Test
@@ -418,7 +416,7 @@ public class GhRelAssetWagonTest {
         @Test
         public void testGetFileList_EmptyDirectory() throws Exception {
                 String destinationDirectory = "com/example/artifact/1.0.0/";
-                
+
                 // Mock empty release assets response
                 stubFor(get(urlEqualTo("/repos/owner/repo/releases/tags/v1.0.0"))
                         .willReturn(aResponse()
@@ -427,9 +425,9 @@ public class GhRelAssetWagonTest {
                                 .withBody("{\"id\": 12345, \"assets\": []}")));
 
                 when(authenticationInfo.getPassword()).thenReturn("mocked_token");
-                
+
                 List<String> fileList = ghRelAssetWagon.getFileList(destinationDirectory);
-                
+
                 assertNotNull(fileList);
                 assertTrue(fileList.isEmpty());
         }
@@ -437,7 +435,7 @@ public class GhRelAssetWagonTest {
         @Test
         public void testGetFileList_WithFiles() throws Exception {
                 String destinationDirectory = "com/example/artifact/1.0.0/";
-                
+
                 // Mock release with assets
                 stubFor(get(urlEqualTo("/repos/owner/repo/releases/tags/v1.0.0"))
                         .willReturn(aResponse()
@@ -458,7 +456,7 @@ public class GhRelAssetWagonTest {
                                         "    }\n" +
                                         "  ]\n" +
                                         "}")));
-                
+
                 // Mock assets endpoint
                 stubFor(get(urlEqualTo("/repos/owner/repo/releases/12345/assets"))
                         .willReturn(aResponse()
@@ -478,9 +476,9 @@ public class GhRelAssetWagonTest {
                                         "]")));
 
                 when(authenticationInfo.getPassword()).thenReturn("mocked_token");
-                
+
                 List<String> fileList = ghRelAssetWagon.getFileList(destinationDirectory);
-                
+
                 assertNotNull(fileList);
                 assertEquals(2, fileList.size());
                 assertTrue(fileList.contains("artifact-1.0.0.jar"));
@@ -490,7 +488,7 @@ public class GhRelAssetWagonTest {
         @Test
         public void testGetFileList_ReleaseNotFound() throws Exception {
                 String destinationDirectory = "com/example/artifact/1.0.0/";
-                
+
                 // Mock 404 response for non-existent release
                 stubFor(get(urlEqualTo("/repos/owner/repo/releases/tags/v1.0.0"))
                         .willReturn(aResponse()
@@ -499,9 +497,9 @@ public class GhRelAssetWagonTest {
                                 .withBody("{\"message\": \"Not Found\"}")));
 
                 when(authenticationInfo.getPassword()).thenReturn("mocked_token");
-                
+
                 List<String> fileList = ghRelAssetWagon.getFileList(destinationDirectory);
-                
+
                 assertNotNull(fileList);
                 assertTrue(fileList.isEmpty());
         }
@@ -509,87 +507,55 @@ public class GhRelAssetWagonTest {
         @Test
         public void testResourceExists_ExistingResource() throws Exception {
                 String resourceName = "com/example/artifact/1.0.0/artifact-1.0.0.jar";
-                
-                // Mock release with the requested asset
-                stubFor(get(urlEqualTo("/repos/owner/repo/releases/tags/v1.0.0"))
-                        .willReturn(aResponse()
-                                .withStatus(200)
-                                .withHeader("Content-Type", "application/json")
-                                .withBody("{\n" +
-                                        "  \"id\": 12345,\n" +
-                                        "  \"assets\": [\n" +
-                                        "    {\n" +
-                                        "      \"id\": 67890,\n" +
-                                        "      \"name\": \"artifact-1.0.0.jar\",\n" +
-                                        "      \"browser_download_url\": \"https://github.com/owner/repo/releases/download/v1.0.0/artifact-1.0.0.jar\"\n" +
-                                        "    }\n" +
-                                        "  ]\n" +
-                                        "}")));
-                
-                // Mock assets endpoint
-                stubFor(get(urlEqualTo("/repos/owner/repo/releases/12345/assets"))
-                        .willReturn(aResponse()
-                                .withStatus(200)
-                                .withHeader("Content-Type", "application/json")
-                                .withBody("[\n" +
-                                        "  {\n" +
-                                        "    \"id\": 67890,\n" +
-                                        "    \"name\": \"artifact-1.0.0.jar\",\n" +
-                                        "    \"browser_download_url\": \"https://github.com/owner/repo/releases/download/v1.0.0/artifact-1.0.0.jar\"\n" +
-                                        "  }\n" +
-                                        "]")));
 
-                when(authenticationInfo.getPassword()).thenReturn("mocked_token");
-                
+                Path zipPath = tempDir.resolve("test.zip");
+                try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(zipPath))) {
+                    ZipEntry entry = new ZipEntry(resourceName);
+                    zos.putNextEntry(entry);
+                    zos.write("content".getBytes());
+                    zos.closeEntry();
+                }
+
+                ZipCacheManager zipCacheManager = new ZipCacheManager(tempDir);
+                try (InputStream is = Files.newInputStream(zipPath)) {
+                    zipCacheManager.initialize(new GhRelAssetRepository(repository), is);
+                }
+
+                ghRelAssetWagon.setZipCacheManager(zipCacheManager);
+
                 boolean exists = ghRelAssetWagon.resourceExists(resourceName);
-                
+
                 assertTrue(exists);
         }
 
         @Test
         public void testResourceExists_NonExistingResource() throws Exception {
                 String resourceName = "com/example/artifact/1.0.0/nonexistent.jar";
-                
-                // Mock release without the requested asset
-                stubFor(get(urlEqualTo("/repos/owner/repo/releases/tags/v1.0.0"))
-                        .willReturn(aResponse()
-                                .withStatus(200)
-                                .withHeader("Content-Type", "application/json")
-                                .withBody("{\n" +
-                                        "  \"id\": 12345,\n" +
-                                        "  \"assets\": [\n" +
-                                        "    {\n" +
-                                        "      \"id\": 67890,\n" +
-                                        "      \"name\": \"different-file.jar\",\n" +
-                                        "      \"browser_download_url\": \"https://github.com/owner/repo/releases/download/v1.0.0/different-file.jar\"\n" +
-                                        "    }\n" +
-                                        "  ]\n" +
-                                        "}")));
-                
-                // Mock assets endpoint
-                stubFor(get(urlEqualTo("/repos/owner/repo/releases/12345/assets"))
-                        .willReturn(aResponse()
-                                .withStatus(200)
-                                .withHeader("Content-Type", "application/json")
-                                .withBody("[\n" +
-                                        "  {\n" +
-                                        "    \"id\": 67890,\n" +
-                                        "    \"name\": \"different-file.jar\",\n" +
-                                        "    \"browser_download_url\": \"https://github.com/owner/repo/releases/download/v1.0.0/different-file.jar\"\n" +
-                                        "  }\n" +
-                                        "]")));
 
-                when(authenticationInfo.getPassword()).thenReturn("mocked_token");
-                
+                Path zipPath = tempDir.resolve("test.zip");
+                try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(zipPath))) {
+                    ZipEntry entry = new ZipEntry("some/other/file.jar");
+                    zos.putNextEntry(entry);
+                    zos.write("content".getBytes());
+                    zos.closeEntry();
+                }
+
+                ZipCacheManager zipCacheManager = new ZipCacheManager(tempDir);
+                try (InputStream is = Files.newInputStream(zipPath)) {
+                    zipCacheManager.initialize(new GhRelAssetRepository(repository), is);
+                }
+
+                ghRelAssetWagon.setZipCacheManager(zipCacheManager);
+
                 boolean exists = ghRelAssetWagon.resourceExists(resourceName);
-                
+
                 assertFalse(exists);
         }
 
         @Test
         public void testResourceExists_ReleaseNotFound() throws Exception {
                 String resourceName = "com/example/artifact/1.0.0/artifact-1.0.0.jar";
-                
+
                 // Mock 404 response for non-existent release
                 stubFor(get(urlEqualTo("/repos/owner/repo/releases/tags/v1.0.0"))
                         .willReturn(aResponse()
@@ -598,9 +564,9 @@ public class GhRelAssetWagonTest {
                                 .withBody("{\"message\": \"Not Found\"}")));
 
                 when(authenticationInfo.getPassword()).thenReturn("mocked_token");
-                
+
                 boolean exists = ghRelAssetWagon.resourceExists(resourceName);
-                
+
                 assertFalse(exists);
         }
 
@@ -614,12 +580,12 @@ public class GhRelAssetWagonTest {
         public void testPutDirectory_EmptyDirectory() throws Exception {
                 File sourceDirectory = createTempDirectory();
                 String destinationDirectory = "com/example/artifact/1.0.0/";
-                
+
                 // Should not throw exception for empty directory
                 assertDoesNotThrow(() -> {
                         ghRelAssetWagon.putDirectory(sourceDirectory, destinationDirectory);
                 });
-                
+
                 // Clean up
                 sourceDirectory.delete();
         }
@@ -628,20 +594,30 @@ public class GhRelAssetWagonTest {
         public void testPutDirectory_WithFiles() throws Exception {
                 File sourceDirectory = createTempDirectoryWithFiles();
                 String destinationDirectory = "com/example/artifact/1.0.0/";
-                
+
                 when(authenticationInfo.getPassword()).thenReturn("mocked_token");
-                
+
+                doNothing().when(ghRelAssetWagon).put(any(File.class), any(String.class));
+
                 // Mock successful upload responses
                 stubFor(post(urlMatching("/repos/owner/repo/releases/.*/assets.*"))
                         .willReturn(aResponse()
                                 .withStatus(201)
                                 .withHeader("Content-Type", "application/json")
                                 .withBody("{\"id\": 67890, \"name\": \"test-file.txt\"}")));
-                
+
                 assertDoesNotThrow(() -> {
                         ghRelAssetWagon.putDirectory(sourceDirectory, destinationDirectory);
                 });
-                
+
+                ArgumentCaptor<String> destCaptor = ArgumentCaptor.forClass(String.class);
+                verify(ghRelAssetWagon, times(2)).put(any(File.class), destCaptor.capture());
+
+                assertTrue(destCaptor.getAllValues().containsAll(List.of(
+                    "com/example/artifact/1.0.0/test-file.txt",
+                    "com/example/artifact/1.0.0/another-file.xml"
+                )));
+
                 // Clean up
                 deleteDirectory(sourceDirectory);
         }
@@ -651,7 +627,9 @@ public class GhRelAssetWagonTest {
                 String resourceName = "com/example/artifact/1.0.0/artifact-1.0.0.jar";
                 File destination = File.createTempFile("test", ".jar");
                 long timestamp = System.currentTimeMillis() - 86400000; // 1 day ago
-                
+
+                doNothing().when(ghRelAssetWagon).get(resourceName, destination);
+
                 // Mock release with asset that has a newer timestamp
                 stubFor(get(urlEqualTo("/repos/owner/repo/releases/tags/v1.0.0"))
                         .willReturn(aResponse()
@@ -668,7 +646,7 @@ public class GhRelAssetWagonTest {
                                         "    }\n" +
                                         "  ]\n" +
                                         "}")));
-                
+
                 // Mock assets endpoint
                 stubFor(get(urlEqualTo("/repos/owner/repo/releases/12345/assets"))
                         .willReturn(aResponse()
@@ -682,7 +660,7 @@ public class GhRelAssetWagonTest {
                                         "    \"browser_download_url\": \"https://github.com/owner/repo/releases/download/v1.0.0/artifact-1.0.0.jar\"\n" +
                                         "  }\n" +
                                         "]")));
-                
+
                 // Mock file download
                 stubFor(get(urlEqualTo("/owner/repo/releases/download/v1.0.0/artifact-1.0.0.jar"))
                         .willReturn(aResponse()
@@ -690,11 +668,12 @@ public class GhRelAssetWagonTest {
                                 .withBody("mock jar content")));
 
                 when(authenticationInfo.getPassword()).thenReturn("mocked_token");
-                
+
                 boolean result = ghRelAssetWagon.getIfNewer(resourceName, destination, timestamp);
-                
+
                 assertTrue(result, "Should return true when remote file is newer");
-                
+                verify(ghRelAssetWagon, times(1)).get(resourceName, destination);
+
                 // Clean up
                 destination.delete();
         }
@@ -704,7 +683,7 @@ public class GhRelAssetWagonTest {
                 String resourceName = "com/example/artifact/1.0.0/artifact-1.0.0.jar";
                 File destination = File.createTempFile("test", ".jar");
                 long timestamp = System.currentTimeMillis(); // Current time
-                
+
                 // Mock release with asset that has an older timestamp
                 stubFor(get(urlEqualTo("/repos/owner/repo/releases/tags/v1.0.0"))
                         .willReturn(aResponse()
@@ -721,7 +700,7 @@ public class GhRelAssetWagonTest {
                                         "    }\n" +
                                         "  ]\n" +
                                         "}")));
-                
+
                 // Mock assets endpoint
                 stubFor(get(urlEqualTo("/repos/owner/repo/releases/12345/assets"))
                         .willReturn(aResponse()
@@ -737,11 +716,12 @@ public class GhRelAssetWagonTest {
                                         "]")));
 
                 when(authenticationInfo.getPassword()).thenReturn("mocked_token");
-                
+
                 boolean result = ghRelAssetWagon.getIfNewer(resourceName, destination, timestamp);
-                
+
                 assertFalse(result, "Should return false when remote file is older");
-                
+                verify(ghRelAssetWagon, times(0)).get(resourceName, destination);
+
                 // Clean up
                 destination.delete();
         }
@@ -757,20 +737,20 @@ public class GhRelAssetWagonTest {
 
         private File createTempDirectoryWithFiles() throws IOException {
                 File tempDir = createTempDirectory();
-                
+
                 // Create some test files
                 File testFile1 = new File(tempDir, "test-file.txt");
                 testFile1.createNewFile();
                 try (java.io.FileWriter writer = new java.io.FileWriter(testFile1)) {
                         writer.write("test content");
                 }
-                
+
                 File testFile2 = new File(tempDir, "another-file.xml");
                 testFile2.createNewFile();
                 try (java.io.FileWriter writer = new java.io.FileWriter(testFile2)) {
                         writer.write("<xml>test</xml>");
                 }
-                
+
                 return tempDir;
         }
 
@@ -793,24 +773,24 @@ public class GhRelAssetWagonTest {
         void testPutWithChecksumGeneration() throws Exception {
                 // Setup WireMock stubs
                 setupBasicWireMockStubs();
-                
+
                 // Create test artifact
                 File testArtifact = File.createTempFile("test-artifact", ".jar");
                 try (FileOutputStream fos = new FileOutputStream(testArtifact)) {
                         fos.write("Test artifact content".getBytes());
                 }
-                
+
                 when(authenticationInfo.getPassword()).thenReturn("mocked_token");
-                
+
                 // Connect and put artifact
                 ghRelAssetWagon.connect(repository, authenticationInfo);
                 ghRelAssetWagon.put(testArtifact, "com/example/test-artifact/1.0.0/test-artifact-1.0.0.jar");
-                
+
                 // Verify that checksums were generated and staged
                 // This is verified by checking that the put method completes without errors
                 // and that the artifact is added to the upload queue
                 assertTrue(ghRelAssetWagon.artifactsToUpload.size() >= 1);
-                
+
                 // Clean up
                 testArtifact.delete();
         }
@@ -820,23 +800,23 @@ public class GhRelAssetWagonTest {
         void testPutChecksumFileDoesNotGenerateMoreChecksums() throws Exception {
                 // Setup WireMock stubs
                 setupBasicWireMockStubs();
-                
+
                 // Create test checksum file
                 File checksumFile = File.createTempFile("test-artifact", ".jar.md5");
                 try (FileOutputStream fos = new FileOutputStream(checksumFile)) {
                         fos.write("d41d8cd98f00b204e9800998ecf8427e".getBytes());
                 }
-                
+
                 when(authenticationInfo.getPassword()).thenReturn("mocked_token");
-                
+
                 // Connect and put checksum file
                 ghRelAssetWagon.connect(repository, authenticationInfo);
                 int initialUploadCount = ghRelAssetWagon.artifactsToUpload.size();
                 ghRelAssetWagon.put(checksumFile, "com/example/test-artifact/1.0.0/test-artifact-1.0.0.jar.md5");
-                
+
                 // Verify that only the checksum file itself was staged (no additional checksums generated)
                 assertEquals(initialUploadCount + 1, ghRelAssetWagon.artifactsToUpload.size());
-                
+
                 // Clean up
                 checksumFile.delete();
         }
@@ -846,22 +826,22 @@ public class GhRelAssetWagonTest {
         void testPutPomGeneratesMetadata() throws Exception {
                 // Setup WireMock stubs
                 setupBasicWireMockStubs();
-                
+
                 // Create test POM file
                 File pomFile = File.createTempFile("test-artifact", ".pom");
                 try (FileOutputStream fos = new FileOutputStream(pomFile)) {
                         fos.write("<?xml version=\"1.0\"?><project></project>".getBytes());
                 }
-                
+
                 when(authenticationInfo.getPassword()).thenReturn("mocked_token");
-                
+
                 // Connect and put POM
                 ghRelAssetWagon.connect(repository, authenticationInfo);
                 ghRelAssetWagon.put(pomFile, "com/example/test-artifact/1.0.0/test-artifact-1.0.0.pom");
-                
+
                 // Verify that artifacts were staged (including metadata)
                 assertTrue(ghRelAssetWagon.artifactsToUpload.size() >= 1);
-                
+
                 // Clean up
                 pomFile.delete();
         }
@@ -871,22 +851,22 @@ public class GhRelAssetWagonTest {
         void testPutMainArtifactGeneratesMetadata() throws Exception {
                 // Setup WireMock stubs
                 setupBasicWireMockStubs();
-                
+
                 // Create test JAR file
                 File jarFile = File.createTempFile("test-artifact", ".jar");
                 try (FileOutputStream fos = new FileOutputStream(jarFile)) {
                         fos.write("Test JAR content".getBytes());
                 }
-                
+
                 when(authenticationInfo.getPassword()).thenReturn("mocked_token");
-                
+
                 // Connect and put main artifact
                 ghRelAssetWagon.connect(repository, authenticationInfo);
                 ghRelAssetWagon.put(jarFile, "com/example/test-artifact/1.0.0/test-artifact-1.0.0.jar");
-                
+
                 // Verify that artifacts were staged (including metadata)
                 assertTrue(ghRelAssetWagon.artifactsToUpload.size() >= 1);
-                
+
                 // Clean up
                 jarFile.delete();
         }
@@ -896,22 +876,22 @@ public class GhRelAssetWagonTest {
         void testPutSnapshotVersionGeneratesMetadata() throws Exception {
                 // Setup WireMock stubs
                 setupBasicWireMockStubs();
-                
+
                 // Create test SNAPSHOT JAR file
                 File snapshotJar = File.createTempFile("test-artifact", ".jar");
                 try (FileOutputStream fos = new FileOutputStream(snapshotJar)) {
                         fos.write("Test SNAPSHOT content".getBytes());
                 }
-                
+
                 when(authenticationInfo.getPassword()).thenReturn("mocked_token");
-                
+
                 // Connect and put SNAPSHOT artifact
                 ghRelAssetWagon.connect(repository, authenticationInfo);
                 ghRelAssetWagon.put(snapshotJar, "com/example/test-artifact/1.0.0-SNAPSHOT/test-artifact-1.0.0-SNAPSHOT.jar");
-                
+
                 // Verify that artifacts were staged (including SNAPSHOT metadata)
                 assertTrue(ghRelAssetWagon.artifactsToUpload.size() >= 1);
-                
+
                 // Clean up
                 snapshotJar.delete();
         }
@@ -921,22 +901,22 @@ public class GhRelAssetWagonTest {
         void testPutPluginArtifactGeneratesGroupMetadata() throws Exception {
                 // Setup WireMock stubs
                 setupBasicWireMockStubs();
-                
+
                 // Create test plugin JAR file
                 File pluginJar = File.createTempFile("test-maven-plugin", ".jar");
                 try (FileOutputStream fos = new FileOutputStream(pluginJar)) {
                         fos.write("Test plugin content".getBytes());
                 }
-                
+
                 when(authenticationInfo.getPassword()).thenReturn("mocked_token");
-                
+
                 // Connect and put plugin artifact
                 ghRelAssetWagon.connect(repository, authenticationInfo);
                 ghRelAssetWagon.put(pluginJar, "com/example/plugins/test-maven-plugin/1.0.0/test-maven-plugin-1.0.0.jar");
-                
+
                 // Verify that artifacts were staged (including group-level metadata for plugins)
                 assertTrue(ghRelAssetWagon.artifactsToUpload.size() >= 1);
-                
+
                 // Clean up
                 pluginJar.delete();
         }
@@ -946,24 +926,24 @@ public class GhRelAssetWagonTest {
         void testPutClassifiedArtifactDoesNotGenerateMetadata() throws Exception {
                 // Setup WireMock stubs
                 setupBasicWireMockStubs();
-                
+
                 // Create test classified JAR file (sources)
                 File sourcesJar = File.createTempFile("test-artifact", "-sources.jar");
                 try (FileOutputStream fos = new FileOutputStream(sourcesJar)) {
                         fos.write("Test sources content".getBytes());
                 }
-                
+
                 when(authenticationInfo.getPassword()).thenReturn("mocked_token");
-                
+
                 // Connect and put classified artifact
                 ghRelAssetWagon.connect(repository, authenticationInfo);
                 int initialUploadCount = ghRelAssetWagon.artifactsToUpload.size();
                 ghRelAssetWagon.put(sourcesJar, "com/example/test-artifact/1.0.0/test-artifact-1.0.0-sources.jar");
-                
+
                 // Verify that only the artifact and its checksums were staged (no metadata for classified artifacts)
                 // The exact count depends on implementation, but should be minimal
                 assertTrue(ghRelAssetWagon.artifactsToUpload.size() > initialUploadCount);
-                
+
                 // Clean up
                 sourcesJar.delete();
         }
@@ -973,27 +953,27 @@ public class GhRelAssetWagonTest {
         void testRepositoryStructureTracking() throws Exception {
                 // Setup WireMock stubs
                 setupBasicWireMockStubs();
-                
+
                 when(authenticationInfo.getPassword()).thenReturn("mocked_token");
                 ghRelAssetWagon.connect(repository, authenticationInfo);
-                
+
                 // Put multiple versions of the same artifact
                 File artifact1 = File.createTempFile("test-artifact", ".jar");
                 File artifact2 = File.createTempFile("test-artifact", ".jar");
-                
+
                 try (FileOutputStream fos = new FileOutputStream(artifact1)) {
                         fos.write("Version 1.0.0 content".getBytes());
                 }
                 try (FileOutputStream fos = new FileOutputStream(artifact2)) {
                         fos.write("Version 1.1.0 content".getBytes());
                 }
-                
+
                 ghRelAssetWagon.put(artifact1, "com/example/test-artifact/1.0.0/test-artifact-1.0.0.jar");
                 ghRelAssetWagon.put(artifact2, "com/example/test-artifact/1.1.0/test-artifact-1.1.0.jar");
-                
+
                 // Verify that multiple artifacts were staged
                 assertTrue(ghRelAssetWagon.artifactsToUpload.size() >= 2);
-                
+
                 // Clean up
                 artifact1.delete();
                 artifact2.delete();
@@ -1004,23 +984,23 @@ public class GhRelAssetWagonTest {
         void testPutMalformedPath() throws Exception {
                 // Setup WireMock stubs
                 setupBasicWireMockStubs();
-                
+
                 // Create test artifact
                 File testArtifact = File.createTempFile("test", ".jar");
                 try (FileOutputStream fos = new FileOutputStream(testArtifact)) {
                         fos.write("Test content".getBytes());
                 }
-                
+
                 when(authenticationInfo.getPassword()).thenReturn("mocked_token");
-                
+
                 // Connect and put artifact with malformed path
                 ghRelAssetWagon.connect(repository, authenticationInfo);
-                
+
                 // This should not throw an exception, just handle gracefully
                 assertDoesNotThrow(() -> {
                         ghRelAssetWagon.put(testArtifact, "malformed/path");
                 });
-                
+
                 // Clean up
                 testArtifact.delete();
         }
@@ -1030,21 +1010,21 @@ public class GhRelAssetWagonTest {
                 stubFor(get(urlEqualTo("/repos/owner/repo/releases/tags/v1.0.0"))
                         .willReturn(aResponse()
                                 .withStatus(404)));
-                
+
                 // Mock commit SHA endpoint
                 stubFor(get(urlEqualTo("/repos/owner/repo/git/refs/heads/main"))
                         .willReturn(aResponse()
                                 .withStatus(200)
                                 .withHeader("Content-Type", "application/json")
                                 .withBody("{\"object\":{\"sha\":\"mocked_commit\"}}")));
-                
+
                 // Mock tag creation
                 stubFor(post(urlEqualTo("/repos/owner/repo/git/tags"))
                         .willReturn(aResponse()
                                 .withStatus(201)
                                 .withHeader("Content-Type", "application/json")
                                 .withBody("{\"sha\":\"mocked_tag_sha\"}")));
-                
+
                 // Mock release creation
                 stubFor(post(urlEqualTo("/repos/owner/repo/releases"))
                         .willReturn(aResponse()

--- a/src/test/java/io/github/amadeusitgroup/maven/wagon/ZipCacheManagerTest.java
+++ b/src/test/java/io/github/amadeusitgroup/maven/wagon/ZipCacheManagerTest.java
@@ -1,0 +1,85 @@
+package io.github.amadeusitgroup.maven.wagon;
+
+import org.apache.maven.wagon.repository.Repository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.io.TempDir;
+
+class ZipCacheManagerTest {
+
+  @TempDir
+  Path tempDir;
+
+  GhRelAssetRepository ghRelAssetRepository;
+
+  @BeforeEach
+  void setUp() {
+    ghRelAssetRepository = new GhRelAssetRepository(new Repository("id", "ghrelasset://org/repo/tag/zip.zip"));
+  }
+
+    @Test
+    void testCacheFilename() throws IOException {
+        ZipCacheManager zipCacheManager = new ZipCacheManager(tempDir);
+        zipCacheManager.initialize(ghRelAssetRepository, null);
+
+        Path expectedPath = tempDir.resolve("C7FF432FC21DE2BA73216A62D5EA21EB9564B57C");
+        assertEquals(expectedPath, zipCacheManager.getCacheFile().toPath());
+    }
+
+    @Test
+    void testIsInitialized() throws IOException {
+        ZipCacheManager zipCacheManager = new ZipCacheManager(tempDir);
+        assertFalse(zipCacheManager.isInitialized());
+
+        InputStream inputStream = new ByteArrayInputStream("test data".getBytes(StandardCharsets.UTF_8));
+        zipCacheManager.initialize(ghRelAssetRepository, inputStream);
+
+        assertTrue(zipCacheManager.isInitialized());
+        assertTrue(zipCacheManager.getCacheFile().exists());
+        assertEquals("test data", FileUtils.readFileToString(zipCacheManager.getCacheFile(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void testGetZipFileSystemBeforeInitialization() {
+        ZipCacheManager zipCacheManager = new ZipCacheManager(tempDir);
+        assertThrows(IllegalStateException.class, zipCacheManager::getZipFileSystem);
+    }
+
+    @Test
+    void testGetAndCloseZipFileSystem() throws IOException {
+        ZipCacheManager zipCacheManager = new ZipCacheManager(tempDir);
+
+        // create InputStream for a zip file
+        Path zipPath = tempDir.resolve("testzip");
+        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(zipPath))) {
+            ZipEntry entry = new ZipEntry("testdir/");
+            zos.putNextEntry(entry);
+            zos.closeEntry();
+        }
+        InputStream inputStream = Files.newInputStream(zipPath);
+
+        zipCacheManager.initialize(ghRelAssetRepository, inputStream);
+
+        FileSystem fs = zipCacheManager.getZipFileSystem();
+        assertNotNull(fs);
+        assertTrue(fs.isOpen());
+
+        zipCacheManager.close();
+        assertFalse(fs.isOpen());
+    }
+
+}


### PR DESCRIPTION
Previously the `resourceExists` method would just check if the given release asset exists. Instead we should ensure the zip asset is cached locally and then verify the existence of a given resource inside the zip.